### PR TITLE
update summary manager to allow multiple line answers

### DIFF
--- a/src/helpers/questions-manager.js
+++ b/src/helpers/questions-manager.js
@@ -22,6 +22,7 @@ class QuestionManager {
 
     this.form = document.getElementsByTagName('FORM')[0];
     this.hideFromSummary = this.form.classList.contains('js-question-no-summary');
+    this.multipleLineAnswer = this.form.classList.contains('js-multiple-line-answer');
     this.actionChangingInputs = [...this.form.querySelectorAll('input[data-action-url]')];
 
     const legend = document.querySelector('.ons-fieldset__legend-title ');
@@ -91,7 +92,8 @@ class QuestionManager {
             previousURL: this.previousURL,
             originalPreviousURL: this.originalPreviousURL,
             url: this.url,
-            hideFromSummary: this.hideFromSummary
+            hideFromSummary: this.hideFromSummary,
+            multipleLineAnswer: this.multipleLineAnswer
           };
 
           let action, originalAction;

--- a/src/helpers/questions-manager.js
+++ b/src/helpers/questions-manager.js
@@ -114,7 +114,7 @@ class QuestionManager {
             }
 
             if (abbrElement) {
-              value = input.value + ' ' + label;
+              value = input.value;
             } else {
               switch (input.type) {
                 case 'checkbox':

--- a/src/helpers/summary-manager.js
+++ b/src/helpers/summary-manager.js
@@ -73,7 +73,7 @@ export default class SummaryManager {
           }
         }
 
-        if (answers.length > 3 || question.inputs.find(input => input.checked === true)) {
+        if (answers.length > 3 || question.inputs.find(input => input.checked === true) || question.multipleLineAnswer) {
           joinString = '<br>';
         } else {
           joinString = ' ';


### PR DESCRIPTION
### What is the context of this PR?

Fixes #58 

This PR allows the summary manager in the prototype kit to be able to allow the answers collected to be displayed on multiple lines
### How to review this PR

Check if we can set the answers to display in multiple lines
