### PR TITLE
Update Summary-Manager.Js

### DIFF
--- a/src/helpers/summary-manager.js
+++ b/src/helpers/summary-manager.js
@@ -88,8 +88,8 @@ export default class SummaryManager {
         }
 
         const row = {
-          rowTitle: question.title,
-          rowItems: [
+          title: question.title,
+          itemsList: [
             {
               valueList: [value],
               actions: [
@@ -112,13 +112,13 @@ export default class SummaryManager {
       this.html.push(
         '<div class="ons-summary__item">' + 
         '<dt class="ons-summary__item-title">' +
-          `<div class="ons-summary__item--text">${row.rowTitle}</div>` +
+          `<div class="ons-summary__item--text">${row.title}</div>` +
         '</dt>' +
         '<dd class="ons-summary__values">' + 
-          `<span class="ons-summary__text">${row.rowItems[0].valueList[0].text}</span>`+
+          `<span class="ons-summary__text">${row.itemsList[0].valueList[0].text}</span>`+
         '</dd>' +
         '<dd class="ons-summary__actions">' +
-          `<a href="${row.rowItems[0].actions[0].url}" class="ons-summary__button" aria-label="Change answer">Change</a>` +
+          `<a href="${row.itemsList[0].actions[0].url}" class="ons-summary__button" aria-label="Change answer">Change</a>` +
         '</dd>'+
       '</div>'  
       );

--- a/src/helpers/summary-manager.js
+++ b/src/helpers/summary-manager.js
@@ -133,7 +133,7 @@ export default class SummaryManager {
     });
 
     const tableHeader =
-     '<div class="ons-summary__item ons-u-vh"> <dt>' + 'Question' + '/dt' + '<dd>Answer given</dd>' + '<dd>Change answer</dd>' + '</div>';
+      '<div class="ons-summary__item ons-u-vh"> <dt>' + 'Question' + '/dt' + '<dd>Answer given</dd>' + '<dd>Change answer</dd>' + '</div>';
 
     this.placeholder.insertAdjacentHTML('afterBegin', tableHeader);
   }

--- a/src/helpers/summary-manager.js
+++ b/src/helpers/summary-manager.js
@@ -110,7 +110,7 @@ export default class SummaryManager {
   generateHTML() {
     this.config.forEach(row => {
       this.html.push(
-        '<div class="ons-summary__item">' + 
+        '<div class="ons-summary__item">' +
         '<dt class="ons-summary__item-title">' +
           `<div class="ons-summary__item--text">${row.title}</div>` +
         '</dt>' +

--- a/src/helpers/summary-manager.js
+++ b/src/helpers/summary-manager.js
@@ -110,17 +110,17 @@ export default class SummaryManager {
   generateHTML() {
     this.config.forEach(row => {
       this.html.push(
-        '<tbody class="ons-summary__item">' +
-          '<tr class="ons-summary__row ons-summary__row--has-values">' +
-          '<td class="ons-summary__item-title">' +
+        '<div class="ons-summary__item">' + 
+        '<dt class="ons-summary__item-title">' +
           `<div class="ons-summary__item--text">${row.rowTitle}</div>` +
-          '</td>' +
-          `<td class="ons-summary__values">${row.rowItems[0].valueList[0].text}</td>` +
-          '<td class="ons-summary__actions">' +
+        '</dt>' +
+        '<dd class="ons-summary__values">' + 
+          `<span class="ons-summary__text">${row.rowItems[0].valueList[0].text}</span>`+
+        '</dd>' +
+        '<dd class="ons-summary__actions">' +
           `<a href="${row.rowItems[0].actions[0].url}" class="ons-summary__button" aria-label="Change answer">Change</a>` +
-          '</td>' +
-          '</tr>' +
-          '</tbody>'
+        '</dd>'+
+      '</div>'  
       );
     });
     return this.html;
@@ -133,7 +133,7 @@ export default class SummaryManager {
     });
 
     const tableHeader =
-      '<thead class="ons-u-vh">' + '<tr>' + '<th>Question</th>' + '<th>Answer given</th>' + '<th>Change answer</th>' + '</tr>' + '</thead>';
+     '<div class="ons-summary__item ons-u-vh"> <dt>' + 'Question' + '/dt' + '<dd>Answer given</dd>' + '<dd>Change answer</dd>' + '</div>';
 
     this.placeholder.insertAdjacentHTML('afterBegin', tableHeader);
   }

--- a/src/helpers/summary-manager.js
+++ b/src/helpers/summary-manager.js
@@ -114,7 +114,7 @@ export default class SummaryManager {
         '<dt class="ons-summary__item-title">' +
           `<div class="ons-summary__item--text">${row.title}</div>` +
         '</dt>' +
-        '<dd class="ons-summary__values">' + 
+        '<dd class="ons-summary__values">' +
           `<span class="ons-summary__text">${row.itemsList[0].valueList[0].text}</span>`+
         '</dd>' +
         '<dd class="ons-summary__actions">' +

--- a/src/helpers/summary-manager.js
+++ b/src/helpers/summary-manager.js
@@ -120,7 +120,7 @@ export default class SummaryManager {
         '<dd class="ons-summary__actions">' +
           `<a href="${row.itemsList[0].actions[0].url}" class="ons-summary__button" aria-label="Change answer">Change</a>` +
         '</dd>'+
-      '</div>'  
+      '</div>'
       );
     });
     return this.html;


### PR DESCRIPTION
### What is the context of this PR?

[ONSDESYS-276](https://jira.ons.gov.uk/browse/ONSDESYS-276)

The New Version of Design System doesn't support `.ons-summary__row`,` .ons-summary__row--has-values` anymore. (See this [PR](https://github.com/ONSdigital/design-system/pull/3408)) This breaks the styling in summary page.

This PR fixes class names. Also, instead of `<table>`,  I've used `<dl>` as summary component uses the dl tags. Let me know if that's okay. 

Also changed the param names -  `row.rowTitle` to `row.title` and `row. rowItems` to `row. itemsList` as per the   [migration-guide](https://github.com/ONSdigital/design-system/blob/main/migration_guides/70.x.x-to-72.0.0-migration-guide.md#summary)

### How to review this PR
Checkout to this [PR](https://github.com/ONSdigital/prototype-kit-template/pull/11) in prototype-kit-template and copy these changes to Summary-Manager.Js file. See that these changes fix the styling in summary page.


